### PR TITLE
feat: MobileNumber auth + optional metadata on /employee/login

### DIFF
--- a/src/environment.rs
+++ b/src/environment.rs
@@ -178,18 +178,11 @@ impl AppState {
                 match create_database_pool(&app_config).await {
                     Ok(pool) => {
                         info!("Successfully connected to the local database.");
-                        let vehicle_reader =
-                            Arc::new(DBVehicleReader::new(pool.clone(), &app_config));
-                        // operator and internal reader use ONLY the internal pool
-                        let (
-                            operator_svc,
-                            vehicle_reader_internal,
-                            fleet_op_svc,
-                            internal_pool_opt,
-                        ): (
+                        // Resolve internal pool first so vehicle_reader, employee_reader,
+                        // and fleet_op_svc can all share it.
+                        let (operator_svc, vehicle_reader_internal, internal_pool_opt): (
                             Arc<dyn OperatorService>,
                             Arc<dyn VehicleDataReaderInternal>,
-                            Arc<dyn FleetOperatorService>,
                             Option<PgPool>,
                         ) = if let Some(internal_url) = &app_config.internal_database_url {
                             info!("Connecting to internal database (local)...");
@@ -201,9 +194,6 @@ impl AppState {
                                         Arc::new(DBVehicleReaderInternal::new(
                                             internal_pool.clone(),
                                         )),
-                                        Arc::new(DBFleetOperatorService::new(
-                                            internal_pool.clone(),
-                                        )),
                                         Some(internal_pool),
                                     )
                                 }
@@ -213,8 +203,6 @@ impl AppState {
                                         Arc::new(MockOperatorService::new()),
                                         Arc::new(MockDBVehicleReaderInternal::new())
                                             as Arc<dyn VehicleDataReaderInternal>,
-                                        Arc::new(MockFleetOperatorService::new())
-                                            as Arc<dyn FleetOperatorService>,
                                         None,
                                     )
                                 }
@@ -225,16 +213,27 @@ impl AppState {
                                 Arc::new(MockOperatorService::new()),
                                 Arc::new(MockDBVehicleReaderInternal::new())
                                     as Arc<dyn VehicleDataReaderInternal>,
-                                Arc::new(MockFleetOperatorService::new())
-                                    as Arc<dyn FleetOperatorService>,
                                 None,
                             )
                         };
-                        let employee_reader = Arc::new(DBEmployeeReader::new(
+                        let vehicle_reader = Arc::new(DBVehicleReader::new(
                             pool.clone(),
-                            internal_pool_opt,
+                            internal_pool_opt.clone(),
                             &app_config,
                         ));
+                        let employee_reader = Arc::new(DBEmployeeReader::new(
+                            pool.clone(),
+                            internal_pool_opt.clone(),
+                            &app_config,
+                        ));
+                        let fleet_op_svc: Arc<dyn FleetOperatorService> = match &internal_pool_opt {
+                            Some(internal_pool) => Arc::new(DBFleetOperatorService::new(
+                                internal_pool.clone(),
+                                employee_reader.clone(),
+                                vehicle_reader.clone(),
+                            )),
+                            None => Arc::new(MockFleetOperatorService::new()),
+                        };
                         (
                             vehicle_reader,
                             employee_reader,
@@ -262,12 +261,11 @@ impl AppState {
                 let pool = create_database_pool(&app_config)
                     .await
                     .map_err(|e| anyhow::anyhow!("Failed to create database pool: {}", e))?;
-                let vehicle_reader = Arc::new(DBVehicleReader::new(pool.clone(), &app_config));
-                // operator and internal reader use ONLY the internal pool
-                let (operator_svc, vehicle_reader_internal, fleet_op_svc, internal_pool_opt): (
+                // Resolve internal pool first so vehicle_reader, employee_reader,
+                // and fleet_op_svc can all share it.
+                let (operator_svc, vehicle_reader_internal, internal_pool_opt): (
                     Arc<dyn OperatorService>,
                     Arc<dyn VehicleDataReaderInternal>,
-                    Arc<dyn FleetOperatorService>,
                     Option<PgPool>,
                 ) = if let Some(internal_url) = &app_config.internal_database_url {
                     info!("Connecting to internal database (production)...");
@@ -279,7 +277,6 @@ impl AppState {
                     (
                         Arc::new(DBOperatorService::new(internal_pool.clone())),
                         Arc::new(DBVehicleReaderInternal::new(internal_pool.clone())),
-                        Arc::new(DBFleetOperatorService::new(internal_pool.clone())),
                         Some(internal_pool),
                     )
                 } else {
@@ -288,15 +285,27 @@ impl AppState {
                         Arc::new(MockOperatorService::new()),
                         Arc::new(MockDBVehicleReaderInternal::new())
                             as Arc<dyn VehicleDataReaderInternal>,
-                        Arc::new(MockFleetOperatorService::new()) as Arc<dyn FleetOperatorService>,
                         None,
                     )
                 };
-                let employee_reader = Arc::new(DBEmployeeReader::new(
+                let vehicle_reader = Arc::new(DBVehicleReader::new(
                     pool.clone(),
-                    internal_pool_opt,
+                    internal_pool_opt.clone(),
                     &app_config,
                 ));
+                let employee_reader = Arc::new(DBEmployeeReader::new(
+                    pool.clone(),
+                    internal_pool_opt.clone(),
+                    &app_config,
+                ));
+                let fleet_op_svc: Arc<dyn FleetOperatorService> = match &internal_pool_opt {
+                    Some(internal_pool) => Arc::new(DBFleetOperatorService::new(
+                        internal_pool.clone(),
+                        employee_reader.clone(),
+                        vehicle_reader.clone(),
+                    )),
+                    None => Arc::new(MockFleetOperatorService::new()),
+                };
                 (
                     vehicle_reader,
                     employee_reader,

--- a/src/handlers/routes.rs
+++ b/src/handlers/routes.rs
@@ -4235,25 +4235,36 @@ pub async fn fleet_operator_verify(
     Ok(HttpResponse::Ok().json(response))
 }
 
+#[derive(Debug, Deserialize)]
+pub struct EmployeeLoginQuery {
+    #[serde(rename = "withMetadata")]
+    pub with_metadata: Option<bool>,
+}
+
 #[utoipa::path(
     post,
     path = "/internal/fleet-operator/{gtfs_id}/employee/login",
     tag = "Fleet Operator",
-    params(("gtfs_id" = String, Path, description = "GTFS dataset identifier")),
+    params(
+        ("gtfs_id" = String, Path, description = "GTFS dataset identifier"),
+        ("withMetadata" = Option<bool>, Query, description = "Include employee metadata (name, depot) in the response"),
+    ),
     request_body = EmployeeLoginRequest,
     responses((status = 200, description = "Login response", body = EmployeeLoginResponse))
 )]
 pub async fn fleet_operator_employee_login(
     app_state: Data<AppState>,
     path: Path<String>,
+    query: Query<EmployeeLoginQuery>,
     body: Json<EmployeeLoginRequest>,
 ) -> AppResult<HttpResponse> {
     let gtfs_id = path.into_inner();
     let req = body.into_inner();
+    let with_metadata = query.with_metadata.unwrap_or(false);
 
     let response = app_state
         .fleet_operator_service
-        .login(&gtfs_id, &req)
+        .login(&gtfs_id, &req, with_metadata)
         .await?;
 
     Ok(HttpResponse::Ok().json(response))

--- a/src/models.rs
+++ b/src/models.rs
@@ -739,6 +739,19 @@ pub struct MinimalEmployee {
     pub depot_name: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct EmployeeMetadata {
+    pub first_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mobile_no: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub depot_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub depot_code: Option<String>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DepotManagerDetails {
     #[serde(rename = "depotCode")]

--- a/src/services/db_employee_reader.rs
+++ b/src/services/db_employee_reader.rs
@@ -9,9 +9,34 @@ use std::time::{Duration, SystemTime};
 use tokio::sync::RwLock;
 use tracing::debug;
 
+/// Minimal employee row used by mobile-number login. Depot info is resolved
+/// separately via the depot cache using `entity_id`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct EmployeeLookupRow {
+    pub token_no: Option<String>,
+    pub first_name: String,
+    pub last_name: Option<String>,
+    pub mobile_no: Option<String>,
+    pub entity_id: i64,
+    pub designation_name: Option<String>,
+}
+
 #[async_trait]
 pub trait EmployeeReader: Send + Sync {
     async fn get_employee_by_phone(&self, phone: &str) -> AppResult<Option<MinimalEmployee>>;
+
+    /// Look up an employee in primary `employees` joined with `designations`.
+    async fn lookup_by_mobile_primary(
+        &self,
+        mobile_no: &str,
+    ) -> AppResult<Option<EmployeeLookupRow>>;
+
+    /// Look up an employee in `employees_internal` for the given gtfs_id.
+    async fn lookup_by_mobile_internal(
+        &self,
+        gtfs_id: &str,
+        mobile_no: &str,
+    ) -> AppResult<Option<EmployeeLookupRow>>;
 }
 
 pub struct MockEmployeeReader;
@@ -35,12 +60,30 @@ impl EmployeeReader for MockEmployeeReader {
             "Employee lookup disabled in mock mode".into(),
         ))
     }
+
+    async fn lookup_by_mobile_primary(
+        &self,
+        _mobile_no: &str,
+    ) -> AppResult<Option<EmployeeLookupRow>> {
+        // Mock mode has no data; report a miss rather than an error.
+        // Matches the MockDBVehicleReader::get_depot_info convention.
+        Ok(None)
+    }
+
+    async fn lookup_by_mobile_internal(
+        &self,
+        _gtfs_id: &str,
+        _mobile_no: &str,
+    ) -> AppResult<Option<EmployeeLookupRow>> {
+        Ok(None)
+    }
 }
 
 pub struct DBEmployeeReader {
     pool: PgPool,
     internal_pool: Option<PgPool>,
     cache: Arc<RwLock<HashMap<String, (MinimalEmployee, SystemTime)>>>,
+    lookup_cache: Arc<RwLock<HashMap<String, (EmployeeLookupRow, SystemTime)>>>,
     cache_duration: Duration,
 }
 
@@ -50,6 +93,7 @@ impl DBEmployeeReader {
             pool,
             internal_pool,
             cache: Arc::new(RwLock::new(HashMap::new())),
+            lookup_cache: Arc::new(RwLock::new(HashMap::new())),
             cache_duration: Duration::from_secs(config.cache_duration),
         }
     }
@@ -69,6 +113,23 @@ impl DBEmployeeReader {
     async fn cache_employee_data(&self, employee: &MinimalEmployee, phone: &str) {
         let mut cache = self.cache.write().await;
         cache.insert(phone.to_string(), (employee.clone(), SystemTime::now()));
+    }
+
+    async fn get_cached_lookup(&self, key: &str) -> Option<EmployeeLookupRow> {
+        let cache = self.lookup_cache.read().await;
+        if let Some((row, timestamp)) = cache.get(key) {
+            if timestamp.elapsed().unwrap_or_default() < self.cache_duration {
+                debug!("Cache HIT for employee lookup {}", key);
+                return Some(row.clone());
+            }
+        }
+        debug!("Cache MISS for employee lookup {}", key);
+        None
+    }
+
+    async fn cache_lookup(&self, key: &str, row: &EmployeeLookupRow) {
+        let mut cache = self.lookup_cache.write().await;
+        cache.insert(key.to_string(), (row.clone(), SystemTime::now()));
     }
 }
 
@@ -144,6 +205,115 @@ impl EmployeeReader for DBEmployeeReader {
             Ok(None) => Ok(None),
             Err(e) => Err(AppError::Internal(format!(
                 "DB query error (internal): {}",
+                e
+            ))),
+        }
+    }
+
+    async fn lookup_by_mobile_primary(
+        &self,
+        mobile_no: &str,
+    ) -> AppResult<Option<EmployeeLookupRow>> {
+        let cache_key = format!("primary:{}", mobile_no);
+        if let Some(cached) = self.get_cached_lookup(&cache_key).await {
+            return Ok(Some(cached));
+        }
+
+        // Not single-flighted: concurrent first hits for the same phone will all
+        // query before any writes back to the cache. Acceptable — the dupes only
+        // cost an extra DB round trip on a cold key.
+        //
+        // ORDER BY emp_id DESC makes the lookup deterministic when stale duplicate
+        // rows share a mobile_no (the schema does not enforce uniqueness): prefer
+        // the most recently inserted row, which is the one operations meant to
+        // activate.
+        let query = r#"
+            SELECT
+                e.token_no,
+                e.first_name,
+                e.last_name,
+                e.mobile_no,
+                e.entity_id,
+                LOWER(d.designation_name) AS designation_name
+            FROM employees e
+            LEFT JOIN designations d ON d.designation_id = e.designation_id
+                                    AND d.deleted = false
+            WHERE e.mobile_no = $1
+              AND e.deleted = false
+            ORDER BY e.emp_id DESC
+            LIMIT 1
+        "#;
+
+        match sqlx::query_as::<_, EmployeeLookupRow>(query)
+            .bind(mobile_no)
+            .fetch_optional(&self.pool)
+            .await
+        {
+            Ok(Some(row)) => {
+                debug!("Employee lookup primary HIT for mobile_no {}", mobile_no);
+                self.cache_lookup(&cache_key, &row).await;
+                Ok(Some(row))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(AppError::Internal(format!(
+                "DB query error (primary mobile lookup): {}",
+                e
+            ))),
+        }
+    }
+
+    async fn lookup_by_mobile_internal(
+        &self,
+        gtfs_id: &str,
+        mobile_no: &str,
+    ) -> AppResult<Option<EmployeeLookupRow>> {
+        let cache_key = format!("internal:{}:{}", gtfs_id, mobile_no);
+        if let Some(cached) = self.get_cached_lookup(&cache_key).await {
+            return Ok(Some(cached));
+        }
+
+        let internal_pool = match &self.internal_pool {
+            Some(p) => p,
+            None => return Ok(None),
+        };
+
+        // Not single-flighted, deterministic on duplicates (see lookup_by_mobile_primary).
+        let query = r#"
+            SELECT
+                e.token_no,
+                e.first_name,
+                e.last_name,
+                e.mobile_no,
+                e.entity_id,
+                LOWER(d.designation_name) AS designation_name
+            FROM employees_internal e
+            LEFT JOIN designations_internal d ON d.designation_id = e.designation_id
+                                             AND d.gtfs_id = e.gtfs_id
+                                             AND d.deleted = false
+            WHERE e.mobile_no = $1
+              AND e.gtfs_id = $2
+              AND e.deleted = false
+            ORDER BY e.emp_id DESC
+            LIMIT 1
+        "#;
+
+        match sqlx::query_as::<_, EmployeeLookupRow>(query)
+            .bind(mobile_no)
+            .bind(gtfs_id)
+            .fetch_optional(internal_pool)
+            .await
+        {
+            Ok(Some(row)) => {
+                debug!(
+                    "Employee lookup internal HIT for gtfs_id={} mobile_no={}",
+                    gtfs_id, mobile_no
+                );
+                self.cache_lookup(&cache_key, &row).await;
+                Ok(Some(row))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => Err(AppError::Internal(format!(
+                "DB query error (internal mobile lookup): {}",
                 e
             ))),
         }

--- a/src/services/db_vehicle_reader.rs
+++ b/src/services/db_vehicle_reader.rs
@@ -20,8 +20,16 @@ struct DepotCache {
     depot_names: Option<(Vec<String>, SystemTime)>,
     depot_ids: Option<(Vec<String>, SystemTime)>,
     depot_name_by_id: HashMap<String, (String, SystemTime)>,
+    /// gtfs-aware cache of (entity_name, entity_remark) keyed by (gtfs_id, entity_id).
+    depot_info_by_key: HashMap<(String, i64), (DepotInfo, SystemTime)>,
     vehicles_by_depot_name: HashMap<String, (Vec<DepotVehicleSummary>, SystemTime)>,
     vehicles_by_depot_id: HashMap<String, (Vec<DepotVehicleSummary>, SystemTime)>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DepotInfo {
+    pub name: String,
+    pub code: Option<String>,
 }
 
 // Vehicle pool cache structure
@@ -69,6 +77,10 @@ pub trait VehicleDataReader: Send + Sync {
     async fn get_depot_names(&self) -> AppResult<Vec<String>>;
     async fn get_depot_ids(&self) -> AppResult<Vec<String>>;
     async fn get_depot_name_by_id(&self, depot_id: String) -> AppResult<String>;
+    /// Resolve depot info (name + code) for a gtfs_id + entity_id pair.
+    /// Reads from `entities` (chennai_bus) or `entities_internal` (others).
+    /// Returns `None` if no row matches.
+    async fn get_depot_info(&self, gtfs_id: &str, entity_id: i64) -> AppResult<Option<DepotInfo>>;
     async fn clear_depot_cache(&self) -> AppResult<()>;
     async fn get_vehicle_operation_data(&self, fleet_no: &str) -> AppResult<VehicleOperationData>;
     async fn verify_vehicle(&self, vehicle_no: &str) -> AppResult<bool>;
@@ -183,6 +195,13 @@ impl VehicleDataReader for MockDBVehicleReader {
             "Database is not connected in local testing mode.".to_string(),
         ))
     }
+    async fn get_depot_info(
+        &self,
+        _gtfs_id: &str,
+        _entity_id: i64,
+    ) -> AppResult<Option<DepotInfo>> {
+        Ok(None)
+    }
     async fn clear_depot_cache(&self) -> AppResult<()> {
         Ok(())
     }
@@ -246,6 +265,7 @@ mod tests {
 
 pub struct DBVehicleReader {
     pool: PgPool,
+    internal_pool: Option<PgPool>,
     cache: Arc<RwLock<HashMap<String, (VehicleDataWithRouteId, SystemTime)>>>,
     cache_duration: Duration,
     refresh_locks: Arc<RwLock<HashMap<String, Arc<tokio::sync::Mutex<bool>>>>>,
@@ -260,9 +280,10 @@ pub struct DBVehicleReader {
 }
 
 impl DBVehicleReader {
-    pub fn new(pool: PgPool, config: &AppConfig) -> Self {
+    pub fn new(pool: PgPool, internal_pool: Option<PgPool>, config: &AppConfig) -> Self {
         Self {
             pool,
+            internal_pool,
             cache: Arc::new(RwLock::new(HashMap::new())),
             cache_duration: Duration::from_secs(config.cache_duration),
             refresh_locks: Arc::new(RwLock::new(HashMap::new())),
@@ -270,6 +291,7 @@ impl DBVehicleReader {
                 depot_names: None,
                 depot_ids: None,
                 depot_name_by_id: HashMap::new(),
+                depot_info_by_key: HashMap::new(),
                 vehicles_by_depot_name: HashMap::new(),
                 vehicles_by_depot_id: HashMap::new(),
             })),
@@ -2083,11 +2105,80 @@ impl VehicleDataReader for DBVehicleReader {
         }
     }
 
+    async fn get_depot_info(&self, gtfs_id: &str, entity_id: i64) -> AppResult<Option<DepotInfo>> {
+        // Check cache first
+        {
+            let cache = self.depot_cache.read().await;
+            if let Some((info, timestamp)) = cache
+                .depot_info_by_key
+                .get(&(gtfs_id.to_string(), entity_id))
+            {
+                if !self.is_depot_cache_expired(*timestamp) {
+                    debug!(
+                        "Depot info cache HIT for gtfs_id={} entity_id={}",
+                        gtfs_id, entity_id
+                    );
+                    return Ok(Some(info.clone()));
+                }
+            }
+        }
+        debug!(
+            "Depot info cache MISS for gtfs_id={} entity_id={}",
+            gtfs_id, entity_id
+        );
+
+        // Not single-flighted: concurrent first hits for the same (gtfs_id, entity_id)
+        // will all query. Acceptable — depots are few and rarely change.
+        let result: Result<Option<(String, Option<String>)>, sqlx::Error> =
+            if gtfs_id == crate::services::PRIMARY_GTFS_ID {
+                sqlx::query_as::<_, (String, Option<String>)>(
+                    "SELECT entity_name, entity_remark FROM entities WHERE entity_id = $1",
+                )
+                .bind(entity_id)
+                .fetch_optional(&self.pool)
+                .await
+            } else {
+                let internal_pool = match &self.internal_pool {
+                    Some(p) => p,
+                    None => return Ok(None),
+                };
+                sqlx::query_as::<_, (String, Option<String>)>(
+                    "SELECT entity_name, entity_remark FROM entities_internal \
+                 WHERE entity_id = $1 AND gtfs_id = $2",
+                )
+                .bind(entity_id)
+                .bind(gtfs_id)
+                .fetch_optional(internal_pool)
+                .await
+            };
+
+        match result {
+            Ok(Some((name, code))) => {
+                let info = DepotInfo { name, code };
+                let mut cache = self.depot_cache.write().await;
+                cache.depot_info_by_key.insert(
+                    (gtfs_id.to_string(), entity_id),
+                    (info.clone(), SystemTime::now()),
+                );
+                Ok(Some(info))
+            }
+            Ok(None) => Ok(None),
+            Err(e) => {
+                error!(
+                    "get_depot_info query failed for gtfs_id={} entity_id={}: {}",
+                    gtfs_id, entity_id, e
+                );
+                Err(AppError::Internal(format!("get_depot_info: {}", e)))
+            }
+        }
+    }
+
     async fn clear_depot_cache(&self) -> AppResult<()> {
         let mut cache = self.depot_cache.write().await;
         cache.depot_names = None;
         cache.depot_ids = None;
         cache.depot_name_by_id.clear();
+        cache.depot_info_by_key.clear();
         cache.vehicles_by_depot_name.clear();
         cache.vehicles_by_depot_id.clear();
         info!("Depot cache cleared successfully");

--- a/src/services/fleet_operator.rs
+++ b/src/services/fleet_operator.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::sync::RwLock;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::tools::error::{AppError, AppResult};
 
@@ -89,27 +89,92 @@ pub struct CurrentTripDetailsResponse {
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
 pub enum AuthType {
     Email,
+    MobileNumber,
 }
 
-#[derive(Debug, Clone, Copy, Deserialize, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, utoipa::ToSchema, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {
     Driver,
     Conductor,
+    Manager,
+    #[serde(rename = "driver_conductor")]
+    DriverConductor,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, utoipa::ToSchema, PartialEq, Eq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum EmployeeLoginError {
+    PersonNotFound,
+    TokenMismatch,
+    EmailAuthFailed,
+    MissingMobileNo,
+    MissingEmailHash,
+    MissingPasswordHash,
+    MissingAuthType,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct EmployeeLoginRequest {
     pub auth_type: Option<AuthType>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub email_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub password_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mobile_no: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub token_no: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
 pub struct EmployeeLoginResponse {
     pub verified: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub token: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub role: Option<Role>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<EmployeeLoginError>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<crate::models::EmployeeMetadata>,
+}
+
+/// Maps a designation_name (case-insensitive) to a `Role`.
+///
+/// Real-world designations seen so far:
+/// - primary `designations`: "Driver", "Conductor", "Driver-Conductor", "Admin Manager", "Admin Staff"
+/// - `designations_internal`: "driver", "conductor", "depot_manager"
+///
+/// Rules:
+/// 1. Empty / missing → `None`.
+/// 2. Dual-role ("driver-conductor" / "driver_conductor") is recognised *before* the
+///    single-role substrings so it doesn't get swallowed by the "conductor" branch.
+/// 3. Any title containing "admin" → `None`. This intentionally excludes office roles
+///    like "Admin Manager" and "Admin Staff" from the operational `Role::Manager` bucket
+///    (which is reserved for depot managers).
+/// 4. Otherwise substring match on "conductor" → Conductor, "driver" → Driver,
+///    "manager" → Manager. Anything else → `None`.
+fn map_designation_to_role(designation_name: Option<&str>) -> Option<Role> {
+    let name = designation_name?.trim().to_lowercase();
+    if name.is_empty() {
+        return None;
+    }
+    if name.contains("driver-conductor") || name.contains("driver_conductor") {
+        return Some(Role::DriverConductor);
+    }
+    if name.contains("admin") {
+        return None;
+    }
+    if name.contains("conductor") {
+        Some(Role::Conductor)
+    } else if name.contains("driver") {
+        Some(Role::Driver)
+    } else if name.contains("manager") {
+        Some(Role::Manager)
+    } else {
+        None
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, utoipa::ToSchema)]
@@ -171,6 +236,7 @@ pub trait FleetOperatorService: Send + Sync {
         &self,
         gtfs_id: &str,
         req: &EmployeeLoginRequest,
+        with_metadata: bool,
     ) -> AppResult<EmployeeLoginResponse>;
 
     async fn register(
@@ -258,6 +324,7 @@ impl FleetOperatorService for MockFleetOperatorService {
         &self,
         _gtfs_id: &str,
         _req: &EmployeeLoginRequest,
+        _with_metadata: bool,
     ) -> AppResult<EmployeeLoginResponse> {
         Err(AppError::NotFound(
             "Database is not connected in local testing mode.".to_string(),
@@ -282,14 +349,211 @@ const ROUTE_CACHE_TTL_SECS: u64 = 6 * 3600;
 pub struct DBFleetOperatorService {
     pool: PgPool,
     route_info_cache: Arc<RwLock<HashMap<String, (RouteInfo, SystemTime)>>>,
+    employee_reader: Arc<dyn crate::services::db_employee_reader::EmployeeReader>,
+    vehicle_reader: Arc<dyn crate::services::db_vehicle_reader::VehicleDataReader>,
 }
 
 impl DBFleetOperatorService {
-    pub fn new(pool: PgPool) -> Self {
+    pub fn new(
+        pool: PgPool,
+        employee_reader: Arc<dyn crate::services::db_employee_reader::EmployeeReader>,
+        vehicle_reader: Arc<dyn crate::services::db_vehicle_reader::VehicleDataReader>,
+    ) -> Self {
         Self {
             pool,
             route_info_cache: Arc::new(RwLock::new(HashMap::new())),
+            employee_reader,
+            vehicle_reader,
         }
+    }
+
+    async fn login_email(
+        &self,
+        gtfs_id: &str,
+        req: &EmployeeLoginRequest,
+    ) -> AppResult<EmployeeLoginResponse> {
+        let email_hash = match req.email_hash.as_deref().map(str::trim) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                return Ok(EmployeeLoginResponse {
+                    verified: false,
+                    token: None,
+                    role: None,
+                    error: Some(EmployeeLoginError::MissingEmailHash),
+                    metadata: None,
+                });
+            }
+        };
+        let password_hash = match req.password_hash.as_deref().map(str::trim) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                return Ok(EmployeeLoginResponse {
+                    verified: false,
+                    token: None,
+                    role: None,
+                    error: Some(EmployeeLoginError::MissingPasswordHash),
+                    metadata: None,
+                });
+            }
+        };
+
+        let row: Option<(String, Option<String>)> = sqlx::query_as(
+            r#"
+            SELECT e.token_no, LOWER(d.designation_name)
+            FROM employees_internal e
+            LEFT JOIN designations_internal d
+              ON d.designation_id = e.designation_id
+             AND d.gtfs_id = e.gtfs_id
+             AND d.deleted = false
+            WHERE e.email_hash = $1
+              AND e.password_hash = $2
+              AND e.gtfs_id = $3
+              AND e.deleted = false
+            LIMIT 1
+            "#,
+        )
+        .bind(email_hash)
+        .bind(password_hash)
+        .bind(gtfs_id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| {
+            error!("login failed for gtfs_id={}: {}", gtfs_id, e);
+            AppError::Internal(e.to_string())
+        })?;
+
+        match row {
+            Some((token, designation_name)) => {
+                // Email auth currently masks Manager and DriverConductor → None until the
+                // driver-app Haskell side (Registration.hs:`Just GimsConductor → BUS_CONDUCTOR;
+                // _ → BUS_DRIVER`) is updated to handle the new variants. Remove these filters
+                // once that lands.
+                let role = match map_designation_to_role(designation_name.as_deref()) {
+                    Some(Role::Manager) | Some(Role::DriverConductor) => None,
+                    other => other,
+                };
+                Ok(EmployeeLoginResponse {
+                    verified: true,
+                    token: Some(token),
+                    role,
+                    error: None,
+                    metadata: None,
+                })
+            }
+            None => Ok(EmployeeLoginResponse {
+                verified: false,
+                token: None,
+                role: None,
+                error: Some(EmployeeLoginError::EmailAuthFailed),
+                metadata: None,
+            }),
+        }
+    }
+
+    async fn login_mobile_number(
+        &self,
+        gtfs_id: &str,
+        req: &EmployeeLoginRequest,
+        with_metadata: bool,
+    ) -> AppResult<EmployeeLoginResponse> {
+        let mobile_no = match req.mobile_no.as_deref().map(str::trim) {
+            Some(s) if !s.is_empty() => s,
+            _ => {
+                return Ok(EmployeeLoginResponse {
+                    verified: false,
+                    token: None,
+                    role: None,
+                    error: Some(EmployeeLoginError::MissingMobileNo),
+                    metadata: None,
+                });
+            }
+        };
+
+        // Primary feed → try primary DB first, fall back to internal.
+        // Other gtfs_id → internal only.
+        let row = if gtfs_id == crate::services::PRIMARY_GTFS_ID {
+            match self
+                .employee_reader
+                .lookup_by_mobile_primary(mobile_no)
+                .await?
+            {
+                Some(r) => Some(r),
+                None => {
+                    self.employee_reader
+                        .lookup_by_mobile_internal(gtfs_id, mobile_no)
+                        .await?
+                }
+            }
+        } else {
+            self.employee_reader
+                .lookup_by_mobile_internal(gtfs_id, mobile_no)
+                .await?
+        };
+
+        let row = match row {
+            Some(r) => r,
+            None => {
+                return Ok(EmployeeLoginResponse {
+                    verified: false,
+                    token: None,
+                    role: None,
+                    error: Some(EmployeeLoginError::PersonNotFound),
+                    metadata: None,
+                });
+            }
+        };
+
+        // Optional token verification
+        if let Some(req_token) = req.token_no.as_deref().map(str::trim) {
+            if !req_token.is_empty() && row.token_no.as_deref() != Some(req_token) {
+                return Ok(EmployeeLoginResponse {
+                    verified: false,
+                    token: None,
+                    role: None,
+                    error: Some(EmployeeLoginError::TokenMismatch),
+                    metadata: None,
+                });
+            }
+        }
+
+        let role = map_designation_to_role(row.designation_name.as_deref());
+
+        let metadata = if with_metadata {
+            // Depot lookup is optional context; never fail the login because of it.
+            // Surface the failure in logs instead of swallowing silently so a
+            // backend outage doesn't masquerade as "employee has no depot".
+            let depot = match self
+                .vehicle_reader
+                .get_depot_info(gtfs_id, row.entity_id)
+                .await
+            {
+                Ok(d) => d,
+                Err(e) => {
+                    warn!(
+                        "depot lookup failed for gtfs_id={} entity_id={}: {}",
+                        gtfs_id, row.entity_id, e
+                    );
+                    None
+                }
+            };
+            Some(crate::models::EmployeeMetadata {
+                first_name: row.first_name.clone(),
+                last_name: row.last_name.clone(),
+                mobile_no: row.mobile_no.clone(),
+                depot_name: depot.as_ref().map(|d| d.name.clone()),
+                depot_code: depot.and_then(|d| d.code),
+            })
+        } else {
+            None
+        };
+
+        Ok(EmployeeLoginResponse {
+            verified: true,
+            token: row.token_no,
+            role,
+            error: None,
+            metadata,
+        })
     }
 
     // ── Waybill resolution ───────────────────────────────────────────────────
@@ -1107,65 +1371,19 @@ impl FleetOperatorService for DBFleetOperatorService {
         &self,
         gtfs_id: &str,
         req: &EmployeeLoginRequest,
+        with_metadata: bool,
     ) -> AppResult<EmployeeLoginResponse> {
         match req.auth_type {
-            Some(AuthType::Email) => {
-                let email_hash = req.email_hash.as_ref().ok_or_else(|| {
-                    AppError::BadRequest("email_hash is required for email auth".into())
-                })?;
-                let password_hash = req.password_hash.as_ref().ok_or_else(|| {
-                    AppError::BadRequest("password_hash is required for email auth".into())
-                })?;
-
-                let row: Option<(String, Option<String>)> = sqlx::query_as(
-                    r#"
-                    SELECT e.token_no, LOWER(d.designation_name)
-                    FROM employees_internal e
-                    LEFT JOIN designations_internal d
-                      ON d.designation_id = e.designation_id
-                     AND d.gtfs_id = e.gtfs_id
-                     AND d.deleted = false
-                    WHERE e.email_hash = $1
-                      AND e.password_hash = $2
-                      AND e.gtfs_id = $3
-                      AND e.deleted = false
-                    LIMIT 1
-                    "#,
-                )
-                .bind(email_hash)
-                .bind(password_hash)
-                .bind(gtfs_id)
-                .fetch_optional(&self.pool)
-                .await
-                .map_err(|e| {
-                    error!("login failed for gtfs_id={}: {}", gtfs_id, e);
-                    AppError::Internal(e.to_string())
-                })?;
-
-                match row {
-                    Some((token, designation_name)) => {
-                        let role = designation_name.as_deref().and_then(|n| match n {
-                            "driver" => Some(Role::Driver),
-                            "conductor" => Some(Role::Conductor),
-                            _ => None,
-                        });
-                        Ok(EmployeeLoginResponse {
-                            verified: true,
-                            token: Some(token),
-                            role,
-                        })
-                    }
-                    None => Ok(EmployeeLoginResponse {
-                        verified: false,
-                        token: None,
-                        role: None,
-                    }),
-                }
+            Some(AuthType::Email) => self.login_email(gtfs_id, req).await,
+            Some(AuthType::MobileNumber) => {
+                self.login_mobile_number(gtfs_id, req, with_metadata).await
             }
-            _ => Ok(EmployeeLoginResponse {
+            None => Ok(EmployeeLoginResponse {
                 verified: false,
                 token: None,
                 role: None,
+                error: Some(EmployeeLoginError::MissingAuthType),
+                metadata: None,
             }),
         }
     }
@@ -1180,6 +1398,8 @@ impl FleetOperatorService for DBFleetOperatorService {
                 let name = match role {
                     Role::Driver => "driver",
                     Role::Conductor => "conductor",
+                    Role::Manager => "manager",
+                    Role::DriverConductor => "driver-conductor",
                 };
                 let id: Option<i64> = sqlx::query_scalar(
                     r#"
@@ -1264,5 +1484,512 @@ impl FleetOperatorService for DBFleetOperatorService {
             success: true,
             token_no: req.token_no.clone(),
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::db_employee_reader::{EmployeeLookupRow, EmployeeReader};
+    use crate::services::db_vehicle_reader::{DepotInfo, MockDBVehicleReader, VehicleDataReader};
+    use crate::services::PRIMARY_GTFS_ID;
+    use async_trait::async_trait;
+    use sqlx::postgres::PgPoolOptions;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // ── Stubs ────────────────────────────────────────────────────────────────
+
+    /// Records call counts and returns canned rows per lookup function.
+    struct StubEmployeeReader {
+        primary_row: Option<EmployeeLookupRow>,
+        internal_row: Option<EmployeeLookupRow>,
+        primary_calls: AtomicUsize,
+        internal_calls: AtomicUsize,
+    }
+
+    impl StubEmployeeReader {
+        fn new(primary: Option<EmployeeLookupRow>, internal: Option<EmployeeLookupRow>) -> Self {
+            Self {
+                primary_row: primary,
+                internal_row: internal,
+                primary_calls: AtomicUsize::new(0),
+                internal_calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    #[async_trait]
+    impl EmployeeReader for StubEmployeeReader {
+        async fn get_employee_by_phone(
+            &self,
+            _phone: &str,
+        ) -> AppResult<Option<crate::models::MinimalEmployee>> {
+            Ok(None)
+        }
+        async fn lookup_by_mobile_primary(
+            &self,
+            _mobile_no: &str,
+        ) -> AppResult<Option<EmployeeLookupRow>> {
+            self.primary_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.primary_row.clone())
+        }
+        async fn lookup_by_mobile_internal(
+            &self,
+            _gtfs_id: &str,
+            _mobile_no: &str,
+        ) -> AppResult<Option<EmployeeLookupRow>> {
+            self.internal_calls.fetch_add(1, Ordering::SeqCst);
+            Ok(self.internal_row.clone())
+        }
+    }
+
+    struct StubVehicleReader {
+        depot: Option<DepotInfo>,
+    }
+
+    #[async_trait]
+    impl VehicleDataReader for StubVehicleReader {
+        // Only get_depot_info is exercised; everything else proxies to the mock's behaviour.
+        async fn get_depot_info(
+            &self,
+            _gtfs_id: &str,
+            _entity_id: i64,
+        ) -> AppResult<Option<DepotInfo>> {
+            Ok(self.depot.clone())
+        }
+        // Delegate the rest to MockDBVehicleReader's stub responses by re-implementing as
+        // "not used in these tests" stubs.
+        async fn get_vehicle_data(
+            &self,
+            _vehicle_no: &str,
+            _trip_number: Option<i32>,
+        ) -> AppResult<crate::models::VehicleDataWithRouteId> {
+            unreachable!("not used in login tests")
+        }
+        async fn get_vehicles_by_ids(
+            &self,
+            _vehicle_nos: Vec<String>,
+        ) -> AppResult<Vec<crate::models::VehicleDataWithRouteId>> {
+            Ok(Vec::new())
+        }
+        async fn get_all_vehicles(&self) -> AppResult<Vec<crate::models::VehicleData>> {
+            Ok(Vec::new())
+        }
+        async fn get_vehicles_by_service_type(
+            &self,
+            _service_type: &str,
+        ) -> AppResult<Vec<crate::models::VehicleData>> {
+            Ok(Vec::new())
+        }
+        async fn search_vehicles(
+            &self,
+            _query: &str,
+        ) -> AppResult<Vec<crate::models::VehicleData>> {
+            Ok(Vec::new())
+        }
+        async fn get_vehicle_count(&self) -> AppResult<i64> {
+            Ok(0)
+        }
+        async fn get_vehicles_by_depot_name(
+            &self,
+            _depot_name: &str,
+        ) -> AppResult<Vec<crate::models::DepotVehicleSummary>> {
+            Ok(Vec::new())
+        }
+        async fn get_vehicles_by_depot_id(
+            &self,
+            _depot_id: &str,
+        ) -> AppResult<Vec<crate::models::DepotVehicleSummary>> {
+            Ok(Vec::new())
+        }
+        async fn get_depot_names(&self) -> AppResult<Vec<String>> {
+            Ok(Vec::new())
+        }
+        async fn get_depot_ids(&self) -> AppResult<Vec<String>> {
+            Ok(Vec::new())
+        }
+        async fn get_depot_name_by_id(&self, _depot_id: String) -> AppResult<String> {
+            Err(AppError::NotFound("n/a".into()))
+        }
+        async fn clear_depot_cache(&self) -> AppResult<()> {
+            Ok(())
+        }
+        async fn get_vehicle_operation_data(
+            &self,
+            _fleet_no: &str,
+        ) -> AppResult<crate::models::VehicleOperationData> {
+            Err(AppError::NotFound("n/a".into()))
+        }
+        async fn verify_vehicle(&self, _vehicle_no: &str) -> AppResult<bool> {
+            Ok(false)
+        }
+        async fn get_chennai_waybills_by_route_id(
+            &self,
+            _route_id: &str,
+            _vehicle_number: Option<&str>,
+        ) -> AppResult<Vec<crate::models::VehicleData>> {
+            Ok(Vec::new())
+        }
+        async fn get_chennai_waybill_by_waybill_and_trip(
+            &self,
+            _waybill_no: &str,
+            _trip_number: i32,
+        ) -> AppResult<Vec<crate::models::VehicleData>> {
+            Ok(Vec::new())
+        }
+        async fn get_routes_served_today(
+            &self,
+        ) -> AppResult<Vec<crate::models::RouteLastScheduleTime>> {
+            Ok(Vec::new())
+        }
+        async fn get_vehicles_by_service_tier(
+            &self,
+            _gtfs_id: &str,
+            _service_tier: &str,
+        ) -> AppResult<Vec<String>> {
+            Ok(Vec::new())
+        }
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    fn lookup_row(token: &str, designation: Option<&str>, entity_id: i64) -> EmployeeLookupRow {
+        EmployeeLookupRow {
+            token_no: Some(token.to_string()),
+            first_name: "Test".to_string(),
+            last_name: None,
+            mobile_no: Some("9000000000".to_string()),
+            entity_id,
+            designation_name: designation.map(|s| s.to_string()),
+        }
+    }
+
+    fn build_service(
+        emp: StubEmployeeReader,
+        veh: StubVehicleReader,
+    ) -> (Arc<StubEmployeeReader>, DBFleetOperatorService) {
+        // `pool` is never touched by the mobile-number path; a lazy pool against an
+        // unreachable host is fine for these tests. (Email path is exercised by manual
+        // curl tests against a real DB elsewhere.)
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://nobody:none@127.0.0.1:1/none")
+            .expect("lazy pool builds");
+        let emp_arc = Arc::new(emp);
+        let svc = DBFleetOperatorService::new(
+            pool,
+            emp_arc.clone() as Arc<dyn EmployeeReader>,
+            Arc::new(veh) as Arc<dyn VehicleDataReader>,
+        );
+        (emp_arc, svc)
+    }
+
+    fn mobile_req(mobile: Option<&str>, token: Option<&str>) -> EmployeeLoginRequest {
+        EmployeeLoginRequest {
+            auth_type: Some(AuthType::MobileNumber),
+            email_hash: None,
+            password_hash: None,
+            mobile_no: mobile.map(|s| s.to_string()),
+            token_no: token.map(|s| s.to_string()),
+        }
+    }
+
+    // ── map_designation_to_role ─────────────────────────────────────────────
+
+    #[test]
+    fn role_mapper_handles_real_designations() {
+        // primary `designations` (LOWER()-ed in SQL)
+        assert_eq!(map_designation_to_role(Some("driver")), Some(Role::Driver));
+        assert_eq!(
+            map_designation_to_role(Some("conductor")),
+            Some(Role::Conductor)
+        );
+        assert_eq!(
+            map_designation_to_role(Some("driver-conductor")),
+            Some(Role::DriverConductor),
+            "primary 'Driver-Conductor' must NOT be swallowed by the conductor branch"
+        );
+        assert_eq!(
+            map_designation_to_role(Some("admin manager")),
+            None,
+            "Admin Manager is office staff, not a depot manager"
+        );
+        assert_eq!(map_designation_to_role(Some("admin staff")), None);
+
+        // designations_internal
+        assert_eq!(
+            map_designation_to_role(Some("depot_manager")),
+            Some(Role::Manager)
+        );
+
+        // misc / edge cases
+        assert_eq!(map_designation_to_role(None), None);
+        assert_eq!(map_designation_to_role(Some("")), None);
+        assert_eq!(map_designation_to_role(Some("   ")), None);
+        assert_eq!(
+            map_designation_to_role(Some("DRIVER")),
+            Some(Role::Driver),
+            "case-insensitive"
+        );
+        assert_eq!(
+            map_designation_to_role(Some("ticket inspector")),
+            None,
+            "unknown designations should not be force-bucketed"
+        );
+    }
+
+    // ── login dispatch ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn missing_auth_type_returns_typed_error() {
+        let (_, svc) = build_service(
+            StubEmployeeReader::new(None, None),
+            StubVehicleReader { depot: None },
+        );
+        let req = EmployeeLoginRequest {
+            auth_type: None,
+            email_hash: None,
+            password_hash: None,
+            mobile_no: None,
+            token_no: None,
+        };
+        let resp = svc.login("kolkata_bus", &req, false).await.unwrap();
+        assert!(!resp.verified);
+        assert_eq!(resp.error, Some(EmployeeLoginError::MissingAuthType));
+        assert!(resp.token.is_none());
+        assert!(resp.role.is_none());
+    }
+
+    #[tokio::test]
+    async fn mobile_missing_mobile_no_returns_typed_error() {
+        let (_, svc) = build_service(
+            StubEmployeeReader::new(None, None),
+            StubVehicleReader { depot: None },
+        );
+        let resp = svc
+            .login("kolkata_bus", &mobile_req(None, Some("KDEMP001")), false)
+            .await
+            .unwrap();
+        assert!(!resp.verified);
+        assert_eq!(resp.error, Some(EmployeeLoginError::MissingMobileNo));
+    }
+
+    #[tokio::test]
+    async fn mobile_blank_mobile_no_returns_typed_error() {
+        let (_, svc) = build_service(
+            StubEmployeeReader::new(None, None),
+            StubVehicleReader { depot: None },
+        );
+        let resp = svc
+            .login("kolkata_bus", &mobile_req(Some("   "), None), false)
+            .await
+            .unwrap();
+        assert_eq!(resp.error, Some(EmployeeLoginError::MissingMobileNo));
+    }
+
+    #[tokio::test]
+    async fn chennai_primary_hit_short_circuits_internal() {
+        let (emp_arc, svc) = build_service(
+            StubEmployeeReader::new(
+                Some(lookup_row("O30007", Some("driver"), 42)),
+                Some(lookup_row("OTHER", Some("conductor"), 99)), // must not be reached
+            ),
+            StubVehicleReader { depot: None },
+        );
+        let resp = svc
+            .login(
+                PRIMARY_GTFS_ID,
+                &mobile_req(Some("9361392963"), Some("O30007")),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(resp.verified);
+        assert_eq!(resp.token.as_deref(), Some("O30007"));
+        assert_eq!(resp.role, Some(Role::Driver));
+        assert_eq!(emp_arc.primary_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            emp_arc.internal_calls.load(Ordering::SeqCst),
+            0,
+            "internal lookup must not run when primary hits"
+        );
+    }
+
+    #[tokio::test]
+    async fn chennai_primary_miss_falls_through_to_internal() {
+        let (emp_arc, svc) = build_service(
+            StubEmployeeReader::new(None, Some(lookup_row("MGR_TEST", Some("depot_manager"), 2))),
+            StubVehicleReader { depot: None },
+        );
+        let resp = svc
+            .login(
+                PRIMARY_GTFS_ID,
+                &mobile_req(Some("9000000001"), Some("MGR_TEST")),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(resp.verified);
+        assert_eq!(resp.role, Some(Role::Manager));
+        assert_eq!(emp_arc.primary_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(emp_arc.internal_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn non_chennai_skips_primary() {
+        let (emp_arc, svc) = build_service(
+            StubEmployeeReader::new(
+                Some(lookup_row("MUST_NOT_BE_USED", Some("driver"), 1)),
+                Some(lookup_row("KDEMP001", Some("driver"), 5)),
+            ),
+            StubVehicleReader { depot: None },
+        );
+        let resp = svc
+            .login(
+                "kolkata_bus",
+                &mobile_req(Some("7397438357"), Some("KDEMP001")),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(resp.verified);
+        assert_eq!(resp.token.as_deref(), Some("KDEMP001"));
+        assert_eq!(
+            emp_arc.primary_calls.load(Ordering::SeqCst),
+            0,
+            "primary must not run for non-chennai feeds"
+        );
+        assert_eq!(emp_arc.internal_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn token_mismatch_returns_typed_error() {
+        let (_, svc) = build_service(
+            StubEmployeeReader::new(Some(lookup_row("REAL_TOKEN", Some("driver"), 1)), None),
+            StubVehicleReader { depot: None },
+        );
+        let resp = svc
+            .login(
+                PRIMARY_GTFS_ID,
+                &mobile_req(Some("9361392963"), Some("WRONG")),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(!resp.verified);
+        assert_eq!(resp.error, Some(EmployeeLoginError::TokenMismatch));
+        assert!(resp.token.is_none());
+        assert!(resp.role.is_none());
+    }
+
+    #[tokio::test]
+    async fn token_absent_skips_verification() {
+        let (_, svc) = build_service(
+            StubEmployeeReader::new(Some(lookup_row("REAL_TOKEN", Some("driver"), 1)), None),
+            StubVehicleReader { depot: None },
+        );
+        let resp = svc
+            .login(
+                PRIMARY_GTFS_ID,
+                &mobile_req(Some("9361392963"), None),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(resp.verified);
+        assert_eq!(resp.token.as_deref(), Some("REAL_TOKEN"));
+    }
+
+    #[tokio::test]
+    async fn person_not_found_returns_typed_error() {
+        let (_, svc) = build_service(
+            StubEmployeeReader::new(None, None),
+            StubVehicleReader { depot: None },
+        );
+        let resp = svc
+            .login(
+                PRIMARY_GTFS_ID,
+                &mobile_req(Some("0000000001"), Some("X")),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(!resp.verified);
+        assert_eq!(resp.error, Some(EmployeeLoginError::PersonNotFound));
+    }
+
+    #[tokio::test]
+    async fn with_metadata_populates_depot() {
+        let (_, svc) = build_service(
+            StubEmployeeReader::new(Some(lookup_row("O30007", Some("driver"), 42)), None),
+            StubVehicleReader {
+                depot: Some(DepotInfo {
+                    name: "Poonamallee Depot EV".into(),
+                    code: Some("PN".into()),
+                }),
+            },
+        );
+        let resp = svc
+            .login(
+                PRIMARY_GTFS_ID,
+                &mobile_req(Some("9361392963"), Some("O30007")),
+                true,
+            )
+            .await
+            .unwrap();
+        let meta = resp
+            .metadata
+            .expect("metadata populated when with_metadata=true");
+        assert_eq!(meta.depot_name.as_deref(), Some("Poonamallee Depot EV"));
+        assert_eq!(meta.depot_code.as_deref(), Some("PN"));
+    }
+
+    #[tokio::test]
+    async fn with_metadata_missing_depot_is_tolerated() {
+        let (_, svc) = build_service(
+            StubEmployeeReader::new(Some(lookup_row("O30007", Some("driver"), 9999)), None),
+            StubVehicleReader { depot: None },
+        );
+        let resp = svc
+            .login(
+                PRIMARY_GTFS_ID,
+                &mobile_req(Some("9361392963"), Some("O30007")),
+                true,
+            )
+            .await
+            .unwrap();
+        let meta = resp
+            .metadata
+            .expect("metadata still populated, depot fields null");
+        assert_eq!(meta.depot_name, None);
+        assert_eq!(meta.depot_code, None);
+    }
+
+    #[tokio::test]
+    async fn without_metadata_omits_metadata_field() {
+        let (_, svc) = build_service(
+            StubEmployeeReader::new(Some(lookup_row("O30007", Some("driver"), 42)), None),
+            StubVehicleReader {
+                depot: Some(DepotInfo {
+                    name: "X".into(),
+                    code: Some("X".into()),
+                }),
+            },
+        );
+        let resp = svc
+            .login(
+                PRIMARY_GTFS_ID,
+                &mobile_req(Some("9361392963"), Some("O30007")),
+                false,
+            )
+            .await
+            .unwrap();
+        assert!(resp.metadata.is_none());
+    }
+
+    // Suppress dead-code warning on MockDBVehicleReader so this test module can import it freely.
+    #[allow(dead_code)]
+    fn _ensure_mock_visible() -> MockDBVehicleReader {
+        MockDBVehicleReader::new()
     }
 }

--- a/src/services/gtfs_service.rs
+++ b/src/services/gtfs_service.rs
@@ -98,6 +98,13 @@ impl GTFSService {
             operator_service: std::sync::OnceLock::new(),
         };
 
+        if let Err(e) = service.load_initial_data().await {
+            warn!(
+                "Failed to load initial GTFS data (starting with empty data): {}",
+                e
+            );
+        }
+
         Ok(service)
     }
 

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,10 @@
+/// The gtfs_id whose data lives in the **primary** Postgres pool
+/// (`employees`, `entities`, `designations`). All other gtfs_ids are
+/// served from the internal pool (`employees_internal`, `entities_internal`,
+/// `designations_internal`). Used by fleet_operator login dispatch and
+/// db_vehicle_reader depot lookup.
+pub const PRIMARY_GTFS_ID: &str = "chennai_bus";
+
 pub mod chalo_vehicle_cache;
 pub mod db_employee_reader;
 pub mod db_vehicle_reader;

--- a/src/swagger.rs
+++ b/src/swagger.rs
@@ -125,6 +125,8 @@ use crate::services::operator::QueryBody;
         models::NandiPattern,
         models::NandiPatternDetails,
         models::MinimalEmployee,
+        models::EmployeeMetadata,
+        crate::services::fleet_operator::EmployeeLoginError,
         routes::GetAllRoutesByIdsRequest,
         routes::GetAllStopsByIdsRequest,
         routes::GetAllRouteStopMappingsByRouteCodesRequest,


### PR DESCRIPTION
## Summary

Extends `POST /internal/fleet-operator/{gtfs_id}/employee/login` with a second auth flow and optional richer responses, consolidating the conductor/manager lookup use case into the existing endpoint rather than adding a new one.

### New behaviour

- **`auth_type: \"MobileNumber\"`** — verify an employee by `mobile_no` + optional `token_no`. Existing `Email` auth is unchanged on the success path.
- **`?withMetadata=true`** — optional query param; when set, the response includes `EmployeeMetadata { first_name, last_name, mobile_no, depot_name, depot_code }`.
- **gtfs_id routing for mobile auth**:
  - `chennai_bus` → primary `employees`+`designations` first, fall back to `employees_internal`+`designations_internal`.
  - Any other `gtfs_id` → internal pool only, filtered by `e.gtfs_id`.
- **Optional token verification** — when `token_no` is absent the server returns `verified: true` if the phone resolves; when present, it must match.
- **Typed error reasons** added: `PERSON_NOT_FOUND`, `TOKEN_MISMATCH`, `EMAIL_AUTH_FAILED`, `MISSING_MOBILE_NO`, `MISSING_EMAIL_HASH`, `MISSING_PASSWORD_HASH`, `MISSING_AUTH_TYPE`.
- **`Role::Manager`** added (`driver | conductor | manager`). Email path filters `Manager` to `None` for now so the driver-app Haskell catch-all stays correct until that side is updated.
- **Depot info** comes from a new gtfs-aware in-memory cache on `DBVehicleReader` (`entity_id` → `{ name, code }`, 2-hour TTL), populated lazily from `entities` or `entities_internal`. No more `entities` JOIN in the employee query.

### Notes

- Backward-compatible for existing email-auth callers — success responses are unchanged. Failure responses now include an `error` field (additive).
- `GTFSService::load_initial_data` start-up failures are now soft (logs `warn!`) instead of crashing the boot. **Will be split into its own PR** after a follow-up commit.

## Test plan

- [x] Email auth — valid creds, kolkata_bus → `verified:true, role:driver`
- [x] Email auth — wrong hashes → `verified:false, error:EMAIL_AUTH_FAILED`
- [x] Mobile — kolkata_bus, internal-only path → success
- [x] Mobile — kolkata_bus + `withMetadata=true` → metadata populated
- [x] Mobile — chennai_bus, primary hit, `withMetadata=true` → success
- [x] Mobile — no `token_no` → verification skipped, `verified:true`
- [x] Mobile — wrong token → `TOKEN_MISMATCH`
- [x] Mobile — nonexistent phone → `PERSON_NOT_FOUND`
- [x] Mobile — missing `mobile_no` → `MISSING_MOBILE_NO`
- [x] Mobile — chennai_bus → internal fallback for a Manager → `role:manager`