### PR TITLE
docs: document TRAVELLER as a recognized service_sub_types tag

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -364,6 +364,9 @@ pub struct VehicleServiceTypeResponse {
     pub driver_id: Option<String>,
     pub conductor_id: Option<String>,
     pub eligible_pass_ids: Option<Vec<String>>,
+    /// Free-form tags sourced from assets/vehicle_service_sub_types.csv. Recognized values
+    /// consumed by the domain backend: "LF" (low floor), "EV" (electric vehicle),
+    /// "TRAVELLER" (tempo traveller vehicle, as opposed to a standard bus).
     pub service_sub_types: Option<Vec<String>>,
     #[serde(rename = "seatLayoutId")]
     pub seat_layout_id: Option<String>,
@@ -384,6 +387,9 @@ pub struct VehicleServiceTypeResponse {
 pub struct VehicleMetadataResponse {
     #[serde(rename = "serviceType")]
     pub service_type: Option<String>,
+    /// Free-form tags sourced from assets/vehicle_service_sub_types.csv. Recognized values
+    /// consumed by the domain backend: "LF" (low floor), "EV" (electric vehicle),
+    /// "TRAVELLER" (tempo traveller vehicle, as opposed to a standard bus).
     #[serde(rename = "serviceSubTypes")]
     pub service_sub_types: Option<Vec<String>>,
     #[serde(rename = "busTagNumber")]


### PR DESCRIPTION
## Summary
- `service_sub_types` on `VehicleServiceTypeResponse`/`VehicleMetadataResponse` is a free-form `Vec<String>` sourced from `assets/vehicle_service_sub_types.csv`, so no schema/validation change is needed to support a new tag.
- Documents `TRAVELLER` (tempo traveller vehicle) alongside the existing `LF`/`EV` tags for discoverability, matching the corresponding `ServiceSubType` addition in the nammayatri domain backend.
- Actual tagging of traveller vehicle numbers in the CSV is a data-entry task, not part of this change.

## Test plan
- [x] `cargo check` passes (ran via pre-commit hook)
- [ ] Populate `assets/vehicle_service_sub_types.csv` with `"TRAVELLER"` for the relevant vehicle numbers when ready